### PR TITLE
Add .tool-versions to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 #Build artifacts
 bin
 .gradle
+.tool-versions


### PR DESCRIPTION
A very common way to manage runtimes on your local machine is with asdf (https://asdf-vm.com). It is a tool that allows you to install many different runtimes and different versions of those runtimes. You can specify which projects should use which using a `.tool-versions` file somewhere in the upstream folder structure.

This PR adds that file to the `.gitignore` as it should not be committed to version control.